### PR TITLE
prevent invalid 0 value in field entity_id of revision table

### DIFF
--- a/Subscriber/OrderSubscriber.php
+++ b/Subscriber/OrderSubscriber.php
@@ -65,8 +65,8 @@ class OrderSubscriber implements SubscriberInterface
         /** @var sOrder $order */
         $order = $eventArgs->get('subject');
         foreach ($order->sBasketData['content'] as $basketProduct) {
-            // Skip virtual products like discounts.
-            if (0 < $basketProduct['articleID']) {
+            // Skip virtual products like discounts or redeemed coupons.
+            if (!empty($basketProduct['articleID']) && !empty($basketProduct['articleDetailId'])) {
                 $this->revisionRepository->addRevision(
                     'variant',
                     (string) $basketProduct['ordernumber'],


### PR DESCRIPTION
In some cases for example by redeeming a coupon from netiEasyCoupon plugin the `articleDetailId` is null and will be casted to `0`. When this happens the makaira importer stops because the `entity_id` cannot be 0.